### PR TITLE
ujson 5.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "ujson" %}
-{% set version = "4.0.2" %}
-{% set sha256 = "c615a9e9e378a7383b756b7e7a73c38b22aeb8967a8bfbffd4741f7ffd043c4d" %}
+{% set version = "5.1.0" %}
+{% set sha256 = "a88944d2f99db71a3ca0c63d81f37e55b660edde0b07216fb65a3e46403ef004" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -22,21 +23,28 @@ requirements:
   host:
     - python
     - pip
-    - setuptools_scm
-    - msinttypes  # [win and py27]
+    - setuptools >=42
+    - setuptools_scm >=3.4
+    - toml
+    - wheel
   run:
     - python
 
 test:
   imports:
     - ujson
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/ultrajson/ultrajson
   summary: Ultra fast JSON decoder and encoder written in C with Python bindings
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE.txt
-
+  doc_url: https://github.com/ultrajson/ultrajson/blob/main/README.md
   dev_url: https://github.com/ultrajson/ultrajson
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,6 @@ about:
   license_file: LICENSE.txt
   doc_url: https://github.com/ultrajson/ultrajson/blob/main/README.md
   dev_url: https://github.com/ultrajson/ultrajson
-  doc_url: https://github.com/ultrajson/ultrajson/blob/main/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ build:
   number: 0
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
-  skip: true  # [py<36]
 
 requirements:
   build:


### PR DESCRIPTION
Update ujson to 5.1.0

License: https://github.com/ultrajson/ultrajson/blob/5.1.0/LICENSE.txt
Releases: https://github.com/ultrajson/ultrajson/releases
Requirements: 
- https://github.com/ultrajson/ultrajson/blob/5.1.0/pyproject.toml
- https://github.com/ultrajson/ultrajson/blob/5.1.0/setup.cfg
- https://github.com/ultrajson/ultrajson/blob/5.1.0/setup.py

Actions:
1. Skip py<37
2. Update pinnings for setuptools_scm >=3.4 and add wheel
3. Add license_family
4. Add doc_url