### PR TITLE
Update `ujson` to version `4.2.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "ujson" %}
-{% set version = "4.0.2" %}
-{% set sha256 = "c615a9e9e378a7383b756b7e7a73c38b22aeb8967a8bfbffd4741f7ffd043c4d" %}
+{% set version = "4.2.0" %}
+{% set sha256 = "fffe509f556861c7343c6cba57ed05fe7bcf4b48a934a5b946ccb45428cf8883" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,8 @@ requirements:
     - setuptools >=42
     - wheel
     - setuptools_scm
-    - toml >=3.4
+      # our latest supported version of toml is 0.10.2
+    - toml
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<36]
 
 requirements:
   build:
@@ -22,14 +23,20 @@ requirements:
   host:
     - python
     - pip
+    - setuptools >=42
+    - wheel
     - setuptools_scm
-    - msinttypes  # [win and py27]
+    - toml >=3.4
   run:
     - python
 
 test:
   imports:
     - ujson
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/ultrajson/ultrajson

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ about:
   license_file: LICENSE.txt
 
   dev_url: https://github.com/ultrajson/ultrajson
+  doc_url: https://github.com/ultrajson/ultrajson/blob/main/README.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
  `ujson` version `4.2.0`
1. check the upstream
    https://github.com/ultrajson/ultrajson/tree/4.2.0

2. check the pinnings
    https://github.com/ultrajson/ultrajson/blob/4.2.0/setup.py
    https://github.com/ultrajson/ultrajson/blob/4.2.0/setup.cfg
    https://github.com/ultrajson/ultrajson/blob/4.2.0/pyproject.toml
3. check the changelogs
    A change log document was not available in the upstream so, the release documentation was used instead

    https://github.com/ultrajson/ultrajson/releases

    There were no breaking changes mentioned in the 
    releases section

4. additional research
    https://github.com/conda-forge/ujson-feedstock/issues

    There are currently no open issues in `conda-forge` at the time of the review

5. verify dev_url
    https://github.com/ultrajson/ultrajson

6. verify doc_url
    https://github.com/ultrajson/ultrajson/blob/main/README.md

7. pip in the test section
8. veriy the test section
9. additional tests

In order to test the `ujson` package version `4.2.0` the folowing
command was used:
`conda build ujson-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that it is safe to update `ujson` to version `4.2.0`