### PR TITLE
ujson 5.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "ujson" %}
-{% set version = "5.1.0" %}
-{% set sha256 = "a88944d2f99db71a3ca0c63d81f37e55b660edde0b07216fb65a3e46403ef004" %}
+{% set version = "5.4.0" %}
+{% set sha256 = "6b953e09441e307504130755e5bd6b15850178d591f66292bba4608c4f7f9b00" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Update ujson 5.4.0 to fix CVEs: 
- CVE-2021-45958
- CVE-2022-31116
- CVE-2022-31117

License: https://github.com/ultrajson/ultrajson/blob/5.4.0/LICENSE.txt
Releases: https://github.com/ultrajson/ultrajson/releases
Requirements:

https://github.com/ultrajson/ultrajson/blob/5.4.0/pyproject.toml
https://github.com/ultrajson/ultrajson/blob/5.4.0/setup.cfg
https://github.com/ultrajson/ultrajson/blob/5.4.0/setup.py

No actions

