### PR TITLE
ujson 5.10.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,18 @@
 {% set name = "ujson" %}
-{% set version = "5.4.0" %}
-{% set sha256 = "6b953e09441e307504130755e5bd6b15850178d591f66292bba4608c4f7f9b00" %}
+{% set version = "5.10.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: b3cd8f3c5d8c7738257f1018880444f7b7d9b66232c64649f562d7ba86ad4bc1
 
 build:
   number: 0
-  skip: true  # [py<37]
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   build:
@@ -33,14 +31,23 @@ requirements:
 test:
   imports:
     - ujson
+  source_files:
+    - tests
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v
+  # downstreams:
+  #   - anaconda-navigator 2.5.2
+  #   - navigator-updater 0.4.0
+  #   - python-lsp-server 1.10.0
 
 about:
   home: https://github.com/ultrajson/ultrajson
   summary: Ultra fast JSON decoder and encoder written in C with Python bindings
+  description: Ultra fast JSON decoder and encoder written in C with Python bindings
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt


### PR DESCRIPTION
**Destination channel:**

### Links

- [PKG-5011](https://anaconda.atlassian.net/browse/PKG-5011)
- release-notes: https://github.com/ultrajson/ultrajson/releases
- release-diff: https://github.com/ultrajson/ultrajson/compare/5.4.0...5.10.0
- license: https://github.com/ultrajson/ultrajson/blob/main/LICENSE.txt
- requirements-tagged:
  - https://github.com/ultrajson/ultrajson/blob/5.10.0/pyproject.toml
  - https://github.com/ultrajson/ultrajson/blob/5.10.0/setup.cfg
  - https://github.com/ultrajson/ultrajson/blob/5.10.0/setup.py


### Explanation of changes:

- Apply anaconda-lint fixes
- Clean up the recipe
- Add tests

### Notes

- As this package is a dependency of anaconda-navigator I've tested it and other downstream packages, see the [list](https://metayaml-conda.fly.dev/metayaml/reverse_dependencies?name=ujson).
  - No issues found for:
```
  downstreams:
    - anaconda-navigator 2.5.2
    - navigator-updater 0.4.0
    - python-lsp-server 1.10.0
```


[PKG-5011]: https://anaconda.atlassian.net/browse/PKG-5011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ