### PR TITLE
ujson 5.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ujson" %}
-{% set version = "5.11.0" %}
+{% set version = "5.13.0" %}
 
 package:
   name: {{ name }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e204ae6f909f099ba6b6b942131cee359ddda2b6e4ea39c12eb8b991fe2010e0
+  sha256: d62e3d7625384c08082abad81a077af587fdef2761bb14c3822f4234b8d07d75
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   build:
@@ -22,10 +22,8 @@ requirements:
   host:
     - python
     - pip
-    - setuptools >=42
+    - setuptools >=77
     - setuptools_scm >=3.4
-    - toml
-    - wheel
   run:
     - python
 


### PR DESCRIPTION
## ujson 5.13.0

**Destination channel:** defaults

### Links
- [PKG-15969](https://anaconda.atlassian.net/browse/PKG-15969)
- [PyPI](https://pypi.org/project/ujson/5.13.0/)
- [GitHub](https://github.com/ultrajson/ultrajson/releases/tag/5.13.0)

### Explanation of changes:
- Updated ujson from 5.11.0 to 5.13.0 (CVE fix release)
- Bumped minimum Python to 3.10 (`skip: true  # [py<310]`) per upstream `requires-python`
- Updated build deps: `setuptools >=77`, dropped `toml` and `wheel` (aligned with upstream pyproject.toml and conda-forge 5.13.0 recipe)
- No runtime dependency changes (upstream has no `requires_dist`)


[PKG-15969]: https://anaconda.atlassian.net/browse/PKG-15969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ